### PR TITLE
Support storybook 4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-storybook-addon-static-markup",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/register.js
+++ b/register.js
@@ -89,13 +89,18 @@ var StaticMarkup = function (_React$Component) {
     key: 'render',
     value: function render() {
       var markup = this.state.markup;
+      // setting it to true to support past
+      // versions of storybook, which might not
+      // have active property.
 
+      var _props$active = this.props.active,
+          active = _props$active === undefined ? true : _props$active;
 
-      return _react2.default.createElement(
+      return active ? _react2.default.createElement(
         'div',
         { style: styles.markupPanel },
         markup
-      );
+      ) : null;
     }
 
     // This is some cleanup tasks when the StaticMarkup panel is unmounting.
@@ -125,8 +130,9 @@ _addons2.default.register('evgenykochetkov/static-markup', function (api) {
   // Also need to set a unique name to the panel.
   _addons2.default.addPanel('evgenykochetkov/static-markup/panel', {
     title: 'Static Markup',
-    render: function render() {
-      return _react2.default.createElement(StaticMarkup, { channel: _addons2.default.getChannel(), api: api });
+    render: function render(_ref2) {
+      var active = _ref2.active;
+      return _react2.default.createElement(StaticMarkup, { channel: _addons2.default.getChannel(), api: api, active: active });
     }
   });
 });

--- a/src/register.js
+++ b/src/register.js
@@ -40,12 +40,15 @@ class StaticMarkup extends React.Component {
 
   render() {
     const { markup } = this.state;
-
-    return (
+    // setting it to true to support past
+    // versions of storybook, which might not
+    // have active property.
+    const { active = true } = this.props
+    return active ? (
       <div style={styles.markupPanel}>
         { markup }
       </div>
-    );
+    ) : null;
   }
 
   // This is some cleanup tasks when the StaticMarkup panel is unmounting.
@@ -65,8 +68,8 @@ addons.register('evgenykochetkov/static-markup', (api) => {
   // Also need to set a unique name to the panel.
   addons.addPanel('evgenykochetkov/static-markup/panel', {
     title: 'Static Markup',
-    render: () => (
-      <StaticMarkup channel={addons.getChannel()} api={api}/>
+    render: ({active}) => (
+      <StaticMarkup channel={addons.getChannel()} api={api} active={active}/>
     ),
   })
 })


### PR DESCRIPTION
Hi there 👋 

Thanks for the great addon.

I noticed that the addon was showing its content in all the addon tabs on Storybook 4. After reading the docs I see that the addon needs to check a active property passed in.

This code was tested on Storybook 4. But _should_  be fully compatible with Storybook 3.